### PR TITLE
Add gender-based clothing support and proper night vision toggling

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -2,18 +2,29 @@ Config = Config or {}
 
 Config = {
 	Framework = "qb-core", -- "qb-core", "qbox", "esx" or "custom"
-    Inventory = "ox", -- "ox" or "qs" or "qb" or "esx" or "lj" or "ps"
-    Notification = "ox", -- "ox" or "qb" or "esx"
+	Inventory = "ox",    -- "ox" or "qs" or "qb" or "esx" or "lj" or "ps"
+	Notification = "ox", -- "ox" or "qb" or "esx"
 
 	["GasMask"] = {
 		["Item"] = "gasmask",
-		["Clothing"] = 129,
-		["Variation"] = 1,
+		["Clothing"] = {
+			male = { drawable = 129, texture = 1 },
+			female = { drawable = 130, texture = 0 }
+		},
 	},
-		
+
 	["NightVisionGoggles"] = {
 		["Item"] = "nightvision",
-		["Clothing"] = 119,
+		["Clothing"] = {
+			male = {
+				down = { drawable = 118, texture = 0 },
+				up   = { drawable = 119, texture = 0 }
+			},
+			female = {
+				down = { drawable = 117, texture = 0 },
+				up   = { drawable = 118, texture = 0 }
+			}
+		}
 	},
 
 	["NotificationDuration"] = 5000,


### PR DESCRIPTION
- Added GetGender() utility to dynamically determine ped gender (male/female)

- Updated Config usage to support gender-specific clothing for gas masks and night vision goggles

- Modified `UseGasMask` and `UseNightVision` to apply correct clothing based on player gender

- Ensured SetPedPropIndex dynamically selects drawable/texture from config by gender and state